### PR TITLE
Exit with status 0 when EOF on stdin is encountered.

### DIFF
--- a/src/cronolog.c
+++ b/src/cronolog.c
@@ -315,7 +315,7 @@ main(int argc, char **argv)
 	    n_bytes_read = read(0, read_buf, sizeof read_buf);
 	    if (n_bytes_read == 0)
 	    {
-		exit(3);
+		exit(0);
 	    }
 	    if (n_bytes_read < 0)
 	    {


### PR DESCRIPTION
Cronolog has forever returned a status code of 3 when it encounters an EOF on stdin; however, EOF is a normal condition when the upstream process closes its log file or exits and should not be treated as abnormal by cronolog.  A non-zero status impairs the use of cronolog in pipes by making it impossible to determine if the pipeline was successful.  This pull request changes the exit code to 0 when EOF is encountered.